### PR TITLE
feat: Prevent autosave savepoints from being protected

### DIFF
--- a/savepoints/operators.py
+++ b/savepoints/operators.py
@@ -219,6 +219,9 @@ class SAVEPOINTS_OT_toggle_protection(bpy.types.Operator):
     version_id: bpy.props.StringProperty()
 
     def execute(self, context):
+        if self.version_id == "autosave":
+            return {'CANCELLED'}
+
         settings = context.scene.savepoints_settings
 
         target_item = None

--- a/savepoints/ui.py
+++ b/savepoints/ui.py
@@ -19,9 +19,10 @@ class SAVEPOINTS_UL_version_list(bpy.types.UIList):
         else:
             layout.label(text=f"{item.version_id} - {item.note} ({item.timestamp})", icon='FILE_BACKUP')
 
-        lock_icon = 'LOCKED' if item.is_protected else 'UNLOCKED'
-        op = layout.operator("savepoints.toggle_protection", text="", icon=lock_icon, emboss=False)
-        op.version_id = item.version_id
+        if item.version_id != "autosave":
+            lock_icon = 'LOCKED' if item.is_protected else 'UNLOCKED'
+            op = layout.operator("savepoints.toggle_protection", text="", icon=lock_icon, emboss=False)
+            op.version_id = item.version_id
 
     def filter_items(self, context, data, propname):
         items = getattr(data, propname)

--- a/tests/blender/test_retention_policy.py
+++ b/tests/blender/test_retention_policy.py
@@ -300,6 +300,27 @@ def main():
 
         print("Test 6 Passed.")
 
+        print("\n--- Test 7: Autosave Lock Guard ---")
+        # Ensure autosave exists
+        from savepoints.operators import create_snapshot
+        create_snapshot(bpy.context, "autosave", "Auto Save", skip_thumbnail=True)
+
+        # Attempt to lock autosave
+        # Note: In background mode, operators return a set. EXEC_DEFAULT executes directly.
+        res = bpy.ops.savepoints.toggle_protection('EXEC_DEFAULT', version_id="autosave")
+
+        # Verify in manifest that it is NOT protected
+        manifest = core.load_manifest()
+        autosave_entry = next((v for v in manifest["versions"] if v["id"] == "autosave"), None)
+
+        if not autosave_entry:
+            raise RuntimeError("Autosave missing for Test 7")
+
+        if autosave_entry.get("is_protected", False):
+            raise RuntimeError("Autosave was successfully protected (should be forbidden)")
+
+        print("Test 7 Passed.")
+
         print("\nALL TESTS PASSED")
 
     except Exception:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autosave entries can no longer be protected or locked. The protection toggle is now hidden for autosave items in the interface, and the system blocks any attempts to protect autosave snapshots, ensuring they remain in their default unprotected state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->