### PR TITLE
fix: resolve UI list buttons targeting wrong item on scroll

### DIFF
--- a/savepoints/operators.py
+++ b/savepoints/operators.py
@@ -174,11 +174,16 @@ class SAVEPOINTS_OT_set_tag(bpy.types.Operator):
     )
 
     def execute(self, context):
-        if not self.version_id:
+        item = getattr(context, "savepoints_item", None)
+        if item:
+            version_id = item.version_id
+        else:
+            version_id = self.version_id
+        if not version_id:
             return {'CANCELLED'}
 
         try:
-            update_version_tag(self.version_id, self.tag)
+            update_version_tag(version_id, self.tag)
         except Exception as e:
             self.report({'ERROR'}, f"Failed to set tag: {e}")
             return {'CANCELLED'}
@@ -186,9 +191,9 @@ class SAVEPOINTS_OT_set_tag(bpy.types.Operator):
         # Update UI property directly instead of full sync
         settings = context.scene.savepoints_settings
         found = False
-        for item in settings.versions:
-            if item.version_id == self.version_id:
-                item.tag = self.tag
+        for v in settings.versions:
+            if v.version_id == version_id:
+                v.tag = self.tag
                 found = True
                 break
         if not found:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operations now consistently derive and use the active item's version when present, ensuring edits, rescued assets, tag/note updates, protection toggles, and ghost toggles target the correct version.
  * Improved validation, lookups and error messages to reference the effective version, preventing mismatches in list-based workflows.
  * Minor sequencing fixes to ensure follow-up actions apply to the intended item version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->