### PR TITLE
Adds option to detach linked assets on fork

### DIFF
--- a/savepoints/operators_snapshot.py
+++ b/savepoints/operators_snapshot.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from .services.asset_path import unmap_snapshot_paths
 from .services.backup import create_backup, HistoryDirectoryUnavailableError
-from .services.linking import make_all_local_and_clear_assets
+from .services.fork import make_all_local_and_clear_assets
 from .services.manifest import initialize_history_for_path
 from .services.storage import (
     get_parent_path_from_snapshot,

--- a/savepoints/services/fork.py
+++ b/savepoints/services/fork.py
@@ -1,0 +1,54 @@
+import bpy
+
+def make_all_local_and_clear_assets():
+    """
+    Make all linked data local AND clear their asset status.
+    Returns:
+        tuple: (has_changed, cleared_count)
+    """
+    has_changed = False
+    cleared_count = 0
+
+    try:
+        if bpy.data.libraries:
+            try:
+                bpy.ops.wm.make_local(type='ALL')
+                has_changed = True
+            except (RuntimeError, AttributeError):
+                data_collections = [
+                    bpy.data.objects, bpy.data.meshes, bpy.data.materials,
+                    bpy.data.node_groups, bpy.data.textures, bpy.data.images,
+                    bpy.data.actions, bpy.data.collections
+                ]
+
+                found_linked = False
+                for collection in data_collections:
+                    for data_block in collection:
+                        if data_block.library:
+                            data_block.make_local()
+                            found_linked = True
+
+                if found_linked:
+                    has_changed = True
+
+    except Exception as e:
+        print(f"SavePoints: Error during localization: {e}")
+
+    check_collections = [
+        bpy.data.objects,
+        bpy.data.materials,
+        bpy.data.node_groups,
+        bpy.data.collections,
+        bpy.data.actions,
+        bpy.data.worlds
+    ]
+
+    for collection in check_collections:
+        for data_block in collection:
+            if data_block.asset_data:
+                data_block.asset_clear()
+                cleared_count += 1
+                has_changed = True
+                print(f"SavePoints: Cleared asset mark from {data_block.name}")
+
+    return has_changed, cleared_count

--- a/savepoints/services/linking.py
+++ b/savepoints/services/linking.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import bpy
 import json
 import shutil
 from pathlib import Path
@@ -101,57 +100,3 @@ def link_history(source_dir: str | Path, blend_filepath: str) -> str:
         print(f"Warning: Failed to update parent_file in linked manifest: {e}")
 
     return str(target_path)
-
-
-def make_all_local_and_clear_assets():
-    """
-    Make all linked data local AND clear their asset status.
-    Returns:
-        tuple: (has_changed, cleared_count)
-    """
-    has_changed = False
-    cleared_count = 0
-
-    try:
-        if bpy.data.libraries:
-            try:
-                bpy.ops.wm.make_local(type='ALL')
-                has_changed = True
-            except (RuntimeError, AttributeError):
-                data_collections = [
-                    bpy.data.objects, bpy.data.meshes, bpy.data.materials,
-                    bpy.data.node_groups, bpy.data.textures, bpy.data.images,
-                    bpy.data.actions, bpy.data.collections
-                ]
-
-                found_linked = False
-                for collection in data_collections:
-                    for data_block in collection:
-                        if data_block.library:
-                            data_block.make_local()
-                            found_linked = True
-
-                if found_linked:
-                    has_changed = True
-
-    except Exception as e:
-        print(f"SavePoints: Error during localization: {e}")
-
-    check_collections = [
-        bpy.data.objects,
-        bpy.data.materials,
-        bpy.data.node_groups,
-        bpy.data.collections,
-        bpy.data.actions,
-        bpy.data.worlds
-    ]
-
-    for collection in check_collections:
-        for data_block in collection:
-            if data_block.asset_data:
-                data_block.asset_clear()
-                cleared_count += 1
-                has_changed = True
-                print(f"SavePoints: Cleared asset mark from {data_block.name}")
-
-    return has_changed, cleared_count


### PR DESCRIPTION
Implements a new option when forking a savepoint to make all linked data local and clear asset marks. This prevents duplication in the Asset Browser and creates a fully independent file. Includes a new operator property to control this behavior and a service function to handle the localization and asset clearing. Also adds a test case to ensure the functionality works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * When forking savepoint versions, users can now select the unbind linked assets option to convert external asset dependencies into local assets within the forked file.

* **Tests**
  * Added comprehensive test coverage for the unbind linked assets feature, verifying proper functionality when the option is enabled and disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->